### PR TITLE
ignore status packets

### DIFF
--- a/pyads/adsclient.py
+++ b/pyads/adsclient.py
@@ -91,7 +91,7 @@ class AdsClient:
                     newPacket = self.ReadAmsPacketFromSocket()
                     if newPacket.InvokeID == self._CurrentInvokeID:
                         self._CurrentPacket = newPacket
-                    else:
+                    elif newPacket.CommandID != 4:
                         print("Packet dropped:")
                         print(newPacket)
             except (socket.error, select.error, InvalidPacket) as e:


### PR DESCRIPTION
no need to print these packets out, I think they're just the ADS server spamming any connected clients for their status.